### PR TITLE
not allowed to write extended classes in camelcase

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -11,8 +11,8 @@ $aModule = array(
     "url"         => "http://blog.php-dev.info",
     "email"       => "info@php-dev.info",
     "extend"      => array(
-        'oxModule'              => 'ib_DependencyManager/core/ib_DependencyManager_oxModule',
-        'oxModuleInstaller'     => 'ib_DependencyManager/core/ib_DependencyManager_oxModuleInstaller',
+        'oxmodule'              => 'ib_DependencyManager/core/ib_DependencyManager_oxModule',
+        'oxmoduleinstaller'     => 'ib_DependencyManager/core/ib_DependencyManager_oxModuleInstaller',
     ),
     "files"       => array(
         //core-files


### PR DESCRIPTION
because it will create separated module chains if an other module write it lower case